### PR TITLE
Fix: Loading order

### DIFF
--- a/data/lib/lib.lua
+++ b/data/lib/lib.lua
@@ -1,9 +1,9 @@
+-- Core API functions implemented in Lua
+dofile('data/lib/core/core.lua')
+
 -- Customs library:
 dofile('data/lib/features/features.lua')
 dofile('data/lib/quests/quests.lua')
-
--- Core API functions implemented in Lua
-dofile('data/lib/core/core.lua')
 
 -- Compatibility library for our old Lua API
 dofile('data/lib/compat/compat.lua')


### PR DESCRIPTION
Core libs must be loaded before any others, thus avoiding console errors.