### PR TITLE
Wrong version of ring of healing in loot

### DIFF
--- a/data/monster/monsters/arachir_the_ancient_one.xml
+++ b/data/monster/monsters/arachir_the_ancient_one.xml
@@ -59,7 +59,7 @@
 		<item name="black pearl" chance="8980" />
 		<item name="gold coin" countmax="98" chance="100000" />
 		<item name="platinum coin" countmax="5" chance="50000" />
-		<item name="ring of healing (faster regeneration)" chance="11111" />
+		<item name="ring of healing" chance="11111" />
 		<item id="2229" chance="10000" /><!-- skull -->
 		<item name="vampire shield" chance="6300" />
 		<item name="bloody edge" chance="1200" />

--- a/data/monster/monsters/diblis_the_fair.xml
+++ b/data/monster/monsters/diblis_the_fair.xml
@@ -53,7 +53,7 @@
 		<item name="black pearl" chance="8900" countmax="2" />
 		<item name="gold coin" chance="100000" countmax="99" />
 		<item name="platinum coin" chance="50000" countmax="5" />
-		<item name="ring of healing (faster regeneration)" chance="14111" />
+		<item name="ring of healing" chance="14111" />
 		<item id="2229" chance="15000" /><!-- skull -->
 		<item name="vampire shield" chance="2100" />
 		<item name="strong health potion" chance="1500" />

--- a/data/monster/monsters/sir_valorcrest.xml
+++ b/data/monster/monsters/sir_valorcrest.xml
@@ -52,7 +52,7 @@
 		<item name="gold coin" chance="100000" countmax="93" />
 		<item name="platinum coin" chance="50000" countmax="5" />
 		<item name="sword ring" chance="1400" />
-		<item name="ring of healing (faster regeneration)" chance="17111" />
+		<item name="ring of healing" chance="17111" />
 		<item id="2229" chance="15000" /><!-- skull -->
 		<item name="vampire shield" chance="6300" />
 		<item name="chaos mace" chance="250" />

--- a/data/monster/monsters/zevelon_duskbringer.xml
+++ b/data/monster/monsters/zevelon_duskbringer.xml
@@ -56,7 +56,7 @@
 		<item name="black pearl" chance="8000" />
 		<item name="gold coin" chance="100000" countmax="75" />
 		<item name="platinum coin" chance="50000" countmax="5" />
-		<item name="ring of healing (faster regeneration)" chance="11111" />
+		<item name="ring of healing" chance="11111" />
 		<item name="vampire shield" chance="4500" />
 		<item name="strong health potion" chance="4000" />
 		<item name="vampire lord token" chance="100000" />


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
monsters dropping the correct version of ring of healing, unequipped.
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
