### PR TITLE
corrections on npc spawn and inq boss error

### DIFF
--- a/data/creaturescripts/scripts/quests/inquisition/inquisitionQuestBosses.lua
+++ b/data/creaturescripts/scripts/quests/inquisition/inquisitionQuestBosses.lua
@@ -22,6 +22,9 @@ function onKill(player, target)
 
 	local newValue = 2
 	if targetName == 'latrivan' or targetName == 'golgordan' then
+		if Game.getStorageValue(bossStorage) == nil then
+			Game.setStorageValue(bossStorage, 0)
+		end
 		newValue = math.max(0, Game.getStorageValue(bossStorage)) + 1
 	end
 	Game.setStorageValue(bossStorage, newValue)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** players getting stuck on treasure island and console error on boss kill, preventing quest progression:

Lua Script Error: [CreatureScript Interface]
data/creaturescripts/scripts/quests/inquisition/inquisitionQuestBosses.lua:onKill
...ts/scripts/quests/inquisition/inquisitionQuestBosses.lua:25: bad argument # 2 to 'max' (number expected, got nil)
stack traceback:
        [C]: at 0x7ff725936bf0
        [C]: in function 'max'
        ...ts/scripts/quests/inquisition/inquisitionQuestBosses.lua:25: in function

it solved the issue afaik but i feel like there's a better way to prevent this nil call, if so enlighten me please.