### PR TITLE
Fix: Lua door variables don't match global.lua

### DIFF
--- a/data/scripts/actions/others/doors.lua
+++ b/data/scripts/actions/others/doors.lua
@@ -120,12 +120,18 @@ function door.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 end
 
 local doorsSet = {} -- unique value set for door ids
-for _, d in ipairs(questDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
-for _, d in ipairs(levelDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
 for _, d in ipairs(keys) do if doorsSet[d] == nil then doorsSet[d] = true end end
-for _, d in ipairs(horizontalOpenDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
-for _, d in ipairs(verticalOpenDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
-for d, _ in pairs(doors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(openDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(closedDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(lockedDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(openExtraDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(closedExtraDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(openHouseDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+for d, _ in pairs(closedHouseDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+-- for d, _ in pairs(openQuestDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end -- disabled in globa.lua
+for d, _ in pairs(closedQuestDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
+-- for d, _ in pairs(openLevelDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end -- disabled in globa.lua
+for d, _ in pairs(closedLevelDoors) do if doorsSet[d] == nil then doorsSet[d] = true end end
 for i, _ in pairs(doorsSet) do
 	door:id(i)
 end


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

**Issues addressed:** #47 

The door variables in `data/global.lua` were renamed in ca3faa0
and `doors.lua` needs to be adjusted to match.

Without this patch doors cannot be opened in game.

I've copied the new variables from `data/global.lua` into the same code structure as `doors.lua` used before. I've commented out the similarly-disabled lists from `global.lua` to keep the two in sync.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
